### PR TITLE
Exclude signature files from the shaded jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <!-- ================================================================================ -->
     <!-- Repositories -->
     <!-- ================================================================================ -->
-    
+
     <!-- Only needed to reference restx snapshot version, once 0.2.9 will be released, this section
     will be totally useless -->
     <repositories>
@@ -112,6 +112,16 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>net.thecodersbreakfast.restangular.server.rest.application.RestangularComponent</mainClass>


### PR DESCRIPTION
Some dependencies are signed jar and the shade plugin breaks these signatures when producing the final jar, preventing the application to start. This exception is thrown when launching the application: 

```
SecurityException: Invalid signature file digest for Manifest main attributes
```
