### PR TITLE
Merge restx.factory.FactoryMachine provider-configuration file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
                                 </filter>
                             </filters>
                             <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>net.thecodersbreakfast.restangular.server.rest.application.RestangularComponent</mainClass>
                                 </transformer>


### PR DESCRIPTION
Both restangular and restx-core provide implementations of the FactoryMachine class. Therefore both `META-INF/services/restx.factory.FactoryMachine` file must be merged in the shaded jar.
